### PR TITLE
docs: use pnpm run plugins install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In this example plugin we should have content can be defined and then used as a 
 ![Screenshot](https://user-images.githubusercontent.com/220864/99979953-97841d80-2d9f-11eb-9782-5f65817c58f4.PNG)
 
 ## Installing
-npm install ep_template_content
+pnpm run plugins install ep_template_content
 
 or Use the Etherpad ``/admin`` interface.
 


### PR DESCRIPTION
## Summary
Etherpad uses pnpm internally. The canonical install command per [etherpad-lite/doc/plugins.md](https://github.com/ether/etherpad-lite/blob/develop/doc/plugins.md) is `pnpm run plugins install ep_<name>`, not `npm install`. Update README to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)