### PR TITLE
refactor: adopt template helper for 1 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const eejs = require('ep_etherpad-lite/node/eejs/');
 
-exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
-  args.content += eejs.require('ep_template_content/templates/editbarButtons.ejs');
-  return cb();
-};
+exports.eejsBlock_editbarMenuLeft =
+    template('ep_template_content/templates/editbarButtons.ejs');

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts the `template()` helper from `ep_plugin_helpers` for 1 `eejsBlock_*` hook(s) that match the strict-simple shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs');
  cb();
};
```

Replaced with:

```js
exports.eejsBlock_X = template('plugin/template.ejs');
```

Same runtime behavior — eejs renders the same template into the same section. The helper just removes per-plugin re-implementation of the `args.content += eejs.require(...)` boilerplate.

## Out of scope

Hooks with vars, conditional skip logic, or non-eejs content (e.g. raw `<script>` tags being concatenated) are left alone — those need either the helper's `vars`/`skip` callbacks or different helper variants. Part of Phase 4 of the modernization campaign (pilot: ether/ep_align#182, ether/ep_themes#103).